### PR TITLE
Misc improvements

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,12 +1,13 @@
 <package>
-    <description brief="transformation stack">
+    <description brief="Automated computation of geometric transformations">
         This library offers a transformation stack. One may register data streams
 	together with a source and a target frame. As soon as a transformation from
 	source to target and a data sample is availabe, one get's called back with
 	the transformation and the data sample. Through this mechanism is is possible,
 	the receive any data sample in any frame wanted.
-    </description>                                                                                                                             
+    </description>
     <author>Janosch Machowinski/janosch.machowinski@dfki.de</author>
+    <author>Sylvain Joyeux/sylvain.joyeux@m4x.org</author>
     <copyright>
         DFKI/robotik@dfki.de
     </copyright>

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -1,4 +1,5 @@
-rock_ruby_library(transformer lib/transformer.rb lib/transformer)
+rock_add_ruby_package(transformer
+    RUBY_FILES lib/transformer.rb lib/transformer)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/lib/syskit_plugin.rb
         DESTINATION ${CMAKE_INSTALL_PREFIX}/share/orogen/plugins/syskit
         RENAME transformer_plugin.rb)

--- a/ruby/lib/transformer.rb
+++ b/ruby/lib/transformer.rb
@@ -397,20 +397,34 @@ module Transformer
 
     # Class that represents the transformer configuration
     class Configuration
+        # The set of known transformations
+        #
+        # @return [Hash<(String,String),StaticTransform|DynamicTransform>]
         attr_accessor :transforms
+
+        # The set of registered example transformations
+        #
+        # @return [Hash<(String,String),StaticTransform>]
+        attr_accessor :example_transforms
+
+        # The set of known frame names
+        #
+        # @return [Set<String>]
         attr_accessor :frames
         attr_accessor :checker
 
         def initialize(checker = ConfigurationChecker.new)
             @transforms = Hash.new
             @frames = Set.new
+            @example_transforms = Hash.new
             @checker = checker
         end
 
         def initialize_copy(old)
-            @checker = old.checker
             @transforms = Hash.new
             @frames = Set.new
+            @example_transforms = Hash.new
+            @checker = old.checker
             merge(old)
         end
 
@@ -469,16 +483,15 @@ module Transformer
         # @param [Configuration] conf
         # @return self
         def merge(conf)
-            new_transforms = conf.transforms.map_value do |_, v|
-                v.dup
-            end
-            transforms.merge!(new_transforms)
+            transforms.merge!(conf.transforms.map_value { |_, v| v.dup })
+            example_transforms.merge!(conf.example_transforms.map_value { |_, v| v.dup })
             @frames |= conf.frames
             self
         end
 
         def clear
             transforms.clear
+            example_transforms.clear
             frames.clear
         end
 
@@ -511,6 +524,9 @@ module Transformer
 	    add_transform(tr)
         end
     
+        # Declare a transformation
+        #
+        # @see static_transform dynamic_transform
 	def add_transform(tr)
             checker.check_transformation(frames, tr)
 	    if tr.from == tr.to
@@ -519,13 +535,29 @@ module Transformer
             transforms[[tr.from, tr.to]] = tr
 	end
 
-        # call-seq:
-        #   static_transform translation, "from_frame" => "to_frame"
-        #   static_transform rotation, "from_frame" => "to_frame"
-        #   static_transform translation, rotation, "from_frame" => "to_frame"
+        # Registers a transformation object as begin an example transformation
+        # for a given frame change
         #
-        # Declares a new static transformation
-        def static_transform(*transformation)
+        # @see example_transform
+        def add_example_transform(tr)
+            checker.check_transformation(frames, tr)
+	    if tr.from == tr.to
+		raise ArgumentError, "trying to register a transformation from #{tr.from} onto itself"
+	    end
+            example_transforms[[tr.from, tr.to]] = tr
+        end
+
+        # @api private
+        #
+        # Validates that the arguments passed to {static_transform} and
+        # {example_transform} match the required format, and normalizes them
+        #
+        # @overload validate_static_transform_arguments(position, rotation, from => to)
+        # @overload validate_static_transform_arguments(rotation, from => to)
+        # @overload validate_static_transform_arguments(position, from => to)
+        #
+        # @return [Eigen::Vector3,Eigen::Quaternion]
+        def validate_static_transform_arguments(*transformation)
             from, to = parse_single_transform(transformation.pop)
             if !from || from.empty?
                 raise ArgumentError, "nil or empty frame given for 'from'"
@@ -537,26 +569,67 @@ module Transformer
 
             if transformation.empty?
                 raise ArgumentError, "no transformation given"
-            elsif transformation.size <= 2
-                translation, rotation = transformation
-                if translation.kind_of?(Eigen::Quaternion)
-                    translation, rotation = rotation, translation
-                end
-                translation ||= Eigen::Vector3.new(0, 0, 0)
-                rotation    ||= Eigen::Quaternion.Identity
-
-                if !translation.kind_of?(Eigen::Vector3)
-                    raise ArgumentError, "the provided translation is not an Eigen::Vector3"
-                end
-                if !rotation.kind_of?(Eigen::Quaternion)
-                    raise ArgumentError, "the provided rotation is not an Eigen::Quaternion"
-                end
-            else
-                raise ArgumentError, "#static_transform was expecting either a translation, rotation or both but got #{transformation}"
+            elsif transformation.size > 2
+                raise ArgumentError, "was expecting either a translation, rotation or both but got #{transformation}"
             end
 
+            translation, rotation = transformation
+            if translation.kind_of?(Eigen::Quaternion)
+                translation, rotation = rotation, translation
+            end
+            translation ||= Eigen::Vector3.new(0, 0, 0)
+            rotation    ||= Eigen::Quaternion.Identity
+
+            if !translation.kind_of?(Eigen::Vector3)
+                raise ArgumentError, "the provided translation is not an Eigen::Vector3"
+            end
+            if !rotation.kind_of?(Eigen::Quaternion)
+                raise ArgumentError, "the provided rotation is not an Eigen::Quaternion"
+            end
+            return from, to, translation, rotation
+        end
+
+        # Declares a new static transformation
+        #
+        # @overload static_transform translation, 'from_frame' => 'to_frame'
+        #   Adds a transformation with the specified translation and an identity
+        #   rotation
+        #   @param [Eigen::Vector3] translation the translation
+        #   @return [StaticTransform]
+        #
+        # @overload static_transform rotation, 'from_frame' => 'to_frame'
+        #   Adds a transformation with the specified rotation and a zero
+        #   translation
+        #   @param [Eigen::Quaternion] rotation the rotation
+        #   @return [StaticTransform]
+        #
+        # @overload static_transform translation, rotation, 'from_frame' => 'to_frame'
+        #   Adds a transformation with the specified translation and rotation
+        #
+        #   @param [Eigen::Quaternion] rotation the rotation
+        #   @return [StaticTransform]
+        #
+        def static_transform(*transformation)
+            from, to, translation, rotation = validate_static_transform_arguments(*transformation)
             tr = StaticTransform.new(from, to, translation, rotation)
 	    add_transform(tr)
+            tr
+        end
+
+        # Declares an example transformation between two frames
+        #
+        # This is mostly useful for visualization and design tools which can't
+        # know what values a dynamic transformation would take. The example
+        # transformation can then be used to show a meaningful transform state
+        # instead of taking identity each time
+        #
+        # @see find_example_transform
+        # @return [StaticTransform]
+        def example_transform(*transformation)
+            from, to, translation, rotation = validate_static_transform_arguments(*transformation)
+            tr = StaticTransform.new(from, to, translation, rotation)
+	    add_example_transform(tr)
+            tr
         end
 
         # Checks if a transformation between the provided frames exist.
@@ -594,6 +667,24 @@ module Transformer
             result
         end
 
+        # Returns an example transformation for the given set of frames
+        #
+        # @raise ArgumentError if one of the two frames are not declared
+        # @return [StaticTransform] either an example explicitely declared with
+        #   {example_transform}, or a StaticTransform object that represents
+        #   identity
+        def example_transformation_for(from, to)
+            if result = example_transforms[[from, to]]
+                result
+            elsif !has_frame?(from)
+                raise ArgumentError, "#{from} is not a registered frame"
+            elsif !has_frame?(to)
+                raise ArgumentError, "#{to} is not a registered frame"
+            else
+                StaticTransform.new(from, to, Eigen::Vector3.Zero, Eigen::Quaternion.Identity)
+            end
+        end
+
         # Enumerates the static transformations
         #
         # @yieldparam [StaticTransform] trsf
@@ -612,6 +703,12 @@ module Transformer
             end
         end
 
+        # Enumerates the example transformations
+        #
+        # @yieldparam [StaticTransform] trsf
+        def each_example_transform(&block)
+            example_transforms.each_value(&block)
+        end
 
         def pretty_print(pp)
             pp.text "Transformer configuration"
@@ -638,6 +735,15 @@ module Transformer
                 pp.text "Dynamic Transforms:"
                 pp.nest(2) do
                     each_dynamic_transform do |i|
+                        pp.breakable
+                        i.pretty_print(pp)
+                    end
+                end
+
+                pp.breakable
+                pp.text "Example Transforms:"
+                pp.nest(2) do
+                    each_example_transform do |i|
                         pp.breakable
                         i.pretty_print(pp)
                     end

--- a/ruby/lib/transformer.rb
+++ b/ruby/lib/transformer.rb
@@ -574,7 +574,9 @@ module Transformer
             end
 
             translation, rotation = transformation
-            if translation.kind_of?(Eigen::Quaternion)
+            if translation.kind_of?(Eigen::Isometry3)
+                translation, rotation = translation.translation, translation.rotation
+            elsif translation.kind_of?(Eigen::Quaternion)
                 translation, rotation = rotation, translation
             end
             translation ||= Eigen::Vector3.new(0, 0, 0)

--- a/ruby/lib/transformer.rb
+++ b/ruby/lib/transformer.rb
@@ -385,10 +385,6 @@ module Transformer
 
         def check_frame(frame, frames = nil)
             frame = frame.to_s
-            if frame !~ /^\w+$/
-                raise InvalidConfiguration, "frame names can only contain alphanumeric characters and _, got #{frame}"
-            end
-
             if(frames && !frames.include?(frame))
                 raise InvalidConfiguration, "unknown frame #{frame}, known frames: #{frames.to_a.sort.join(", ")}"
             end

--- a/ruby/lib/transformer.rb
+++ b/ruby/lib/transformer.rb
@@ -531,6 +531,12 @@ module Transformer
         # Declares a new static transformation
         def static_transform(*transformation)
             from, to = parse_single_transform(transformation.pop)
+            if !from || from.empty?
+                raise ArgumentError, "nil or empty frame given for 'from'"
+            end
+            if !to || to.empty?
+                raise ArgumentError, "nil or empty frame given for 'from'"
+            end
             frames(from, to)
 
             if transformation.empty?
@@ -582,9 +588,9 @@ module Transformer
             result = transforms[[from, to]]
             if !result
                 if !has_frame?(from)
-                    raise ArgumentError, "#{from} is not a registered frame"
+                    raise ArgumentError, "#{from} is not a registered frame (#{frames.to_a.sort.join(", ")})"
                 elsif !has_frame?(to)
-                    raise ArgumentError, "#{to} is not a registered frame"
+                    raise ArgumentError, "#{to} is not a registered frame (#{frames.to_a.sort.join(", ")})"
                 else
                     raise ArgumentError, "there is no registered transformations between #{from} and #{to}"
                 end

--- a/ruby/lib/transformer.rb
+++ b/ruby/lib/transformer.rb
@@ -80,7 +80,7 @@ module Transformer
 
         def pretty_print(pp)
             super
-            pp.text ": static"
+            pp.text ": static (xyz=#{translation.to_a.map(&:to_s).join(", ")} rpy=#{rotation.to_euler.to_a.map(&:to_s).join(", ")})"
         end
     end
 

--- a/ruby/lib/transformer/syskit/test.rb
+++ b/ruby/lib/transformer/syskit/test.rb
@@ -1,10 +1,10 @@
-require 'syskit/test'
+require 'syskit/test/self'
 require 'transformer/syskit'
 
 module Transformer
     module SyskitPlugin
         module SelfTest
-            include Syskit::SelfTest
+            include Syskit::Test::Self
 
             def setup
                 super
@@ -12,6 +12,8 @@ module Transformer
                 Syskit.conf.transformer_enabled = true
             end
         end
+        Minitest::Test.include SelfTest
     end
 end
+
 

--- a/ruby/lib/transformer/test.rb
+++ b/ruby/lib/transformer/test.rb
@@ -1,0 +1,69 @@
+# simplecov must be loaded FIRST. Only the files required after it gets loaded
+# will be profiled !!!
+if ENV['TEST_ENABLE_COVERAGE'] == '1'
+    begin
+        require 'simplecov'
+        SimpleCov.start
+    rescue LoadError
+        require 'transformer'
+        Transformer.warn "coverage is disabled because the 'simplecov' gem cannot be loaded"
+    rescue Exception => e
+        require 'transformer'
+        Transformer.warn "coverage is disabled: #{e.message}"
+    end
+end
+
+require 'transformer'
+## Uncomment this to enable flexmock
+# require 'flexmock/test_unit'
+require 'minitest/spec'
+
+if ENV['TEST_ENABLE_PRY'] != '0'
+    begin
+        require 'pry'
+    rescue Exception
+        Transformer.warn "debugging is disabled because the 'pry' gem cannot be loaded"
+    end
+end
+
+module Transformer
+    # This module is the common setup for all tests
+    #
+    # It should be included in the toplevel describe blocks
+    #
+    # @example
+    #   require 'transformer/test'
+    #   describe Transformer do
+    #   end
+    #
+    module SelfTest
+        if defined? FlexMock
+            include FlexMock::ArgumentTypes
+            include FlexMock::MockContainer
+        end
+
+        def setup
+            # Setup code for all the tests
+        end
+
+        def teardown
+            if defined? FlexMock
+                flexmock_teardown
+            end
+            super
+            # Teardown code for all the tests
+        end
+    end
+end
+
+# Workaround a problem with flexmock and minitest not being compatible with each
+# other (currently). See github.com/jimweirich/flexmock/issues/15.
+if defined?(FlexMock) && !FlexMock::TestUnitFrameworkAdapter.method_defined?(:assertions)
+    class FlexMock::TestUnitFrameworkAdapter
+        attr_accessor :assertions
+    end
+    FlexMock.framework_adapter.assertions = 0
+end
+
+Minitest::Test.include Transformer::SelfTest
+

--- a/ruby/lib/transformer/test.rb
+++ b/ruby/lib/transformer/test.rb
@@ -14,8 +14,7 @@ if ENV['TEST_ENABLE_COVERAGE'] == '1'
 end
 
 require 'transformer'
-## Uncomment this to enable flexmock
-# require 'flexmock/test_unit'
+require 'flexmock/test_unit'
 require 'minitest/spec'
 
 if ENV['TEST_ENABLE_PRY'] != '0'

--- a/ruby/test/suite.rb
+++ b/ruby/test/suite.rb
@@ -1,0 +1,4 @@
+require 'transformer/test'
+require './test/test_transformer'
+require './test/test_transformer_configuration'
+

--- a/ruby/test/suite_syskit.rb
+++ b/ruby/test/suite_syskit.rb
@@ -1,12 +1,5 @@
-if !ENV['SYSKIT_ENABLE_COVERAGE']
-    ENV['SYSKIT_ENABLE_COVERAGE'] = '2'
-end
 require './test/syskit/test_composition_extension'
 require './test/syskit/test_syskit_plugin'
 require './test/syskit/test_task_context_extension'
 require './test/syskit/test_transformer'
-
-Transformer.logger = Logger.new(File.open("/dev/null", 'w'))
-Transformer.logger.level = Logger::DEBUG
-Syskit.logger = Logger.new(File.open("/dev/null", 'w'))
 

--- a/ruby/test/syskit/test_composition_extension.rb
+++ b/ruby/test/syskit/test_composition_extension.rb
@@ -1,9 +1,6 @@
-require 'syskit/test'
 require 'transformer/syskit/test'
 
 describe Transformer::CompositionExtension do
-    include Syskit::SelfTest
-
     before do
         Roby.app.using_task_library 'test_transformer'
         ::Robot.logger.level = Logger::WARN

--- a/ruby/test/syskit/test_syskit_plugin.rb
+++ b/ruby/test/syskit/test_syskit_plugin.rb
@@ -1,8 +1,6 @@
 require 'transformer/syskit/test'
 
 describe Transformer::SyskitPlugin do
-    include Transformer::SyskitPlugin::SelfTest
-
     before do
         Syskit::RobyApp::Plugin.start_local_process_server
         Syskit::RobyApp::Plugin.connect_to_local_process_server

--- a/ruby/test/syskit/test_task_context_extension.rb
+++ b/ruby/test/syskit/test_task_context_extension.rb
@@ -1,9 +1,6 @@
-require 'syskit/test'
 require 'transformer/syskit/test'
 
 describe Transformer::TaskContextExtension do
-    include Transformer::SyskitPlugin::SelfTest
-
     before do
         Roby.app.using_task_library 'test_transformer'
         ::Robot.logger.level = Logger::WARN

--- a/ruby/test/syskit/test_transformer.rb
+++ b/ruby/test/syskit/test_transformer.rb
@@ -1,4 +1,3 @@
-require 'syskit/test'
 require 'transformer/syskit/test'
 
 describe Transformer do

--- a/ruby/test/test_transformer.rb
+++ b/ruby/test/test_transformer.rb
@@ -1,10 +1,6 @@
-$LOAD_PATH.unshift(File.expand_path(File.join('..', 'lib'), File.dirname(__FILE__)))
-require 'transformer'
-require 'test/unit'
-require 'eigen'
-require 'pp'
+require 'transformer/test'
 
-class TC_Transformer < Test::Unit::TestCase
+class TC_Transformer < Minitest::Test
     attr_reader :trsf, :transforms
     def conf; trsf.conf end
 

--- a/ruby/test/test_transformer_configuration.rb
+++ b/ruby/test/test_transformer_configuration.rb
@@ -1,115 +1,159 @@
 require 'transformer/test'
 
-class TC_TransformerConfiguration < Minitest::Test
-    attr_reader :conf
+module Transformer
+    describe Configuration do
+        attr_reader :conf
 
-    def setup
-        @conf = Transformer::Configuration.new
-    end
-
-    def test_frame_definition
-        conf.frames :from, :to
-        assert conf.has_frame?('from')
-        assert conf.has_frame?('to')
-    end
-
-    def test_static_transform_definition
-        conf.frames "from", "to1", "to2", "to3"
-
-        trans = Eigen::Vector3.new(0, 2, 0)
-        trans_id = Eigen::Vector3.new(0, 0, 0)
-        rot   = Eigen::Quaternion.new(0, 1, 0, 0)
-        rot_id = Eigen::Quaternion.Identity
-        conf.static_transform trans, 'from' => 'to1'
-        conf.static_transform rot, 'from' => 'to2'
-        conf.static_transform trans, rot, 'from' => 'to3'
-
-        assert conf.has_transformation?("from", "to1")
-        assert conf.has_transformation?("from", "to2")
-        assert conf.has_transformation?("from", "to3")
-            
-        trsf = conf.transformation_for("from", "to1")
-        assert((trsf.translation - trans).norm < 0.001)
-        assert(trsf.rotation.approx?(rot_id, 0.001))
-            
-        trsf = conf.transformation_for("from", "to2")
-        assert((trsf.translation - trans_id).norm < 0.001)
-        assert(trsf.rotation.approx?(rot, 0.001))
-            
-        trsf = conf.transformation_for("from", "to3")
-        assert((trsf.translation - trans).norm < 0.001)
-        assert(trsf.rotation.approx?(rot, 0.001))
-    end
-
-    def test_it_updates_existing_transformations
-        conf.frames "from", "to"
-
-        conf.static_transform Eigen::Vector3.new(0, 0, 0), 'from' => 'to'
-        conf.static_transform Eigen::Vector3.new(1, 0, 0), 'from' => 'to'
-        assert conf.has_transformation?("from", "to")
-
-        assert conf.transformation_for('from', 'to').translation.approx?(Eigen::Vector3.new(1, 0, 0))
-    end
-
-    def test_rejects_wrong_static_transform_definition
-        conf.frames "from", "to"
-
-        assert_raises(ArgumentError) do
-            # No transformation provided
-            conf.static_transform "from" => "to"
+        before do
+            @conf = Transformer::Configuration.new
         end
-        assert_raises(ArgumentError) do
-            conf.static_transform 10, 'from' => 'to'
-        end
-        assert_raises(ArgumentError) do
-            conf.static_transform 10, Eigen::Vector3.new(0, 0, 0), 'from' => 'to'
-        end
-        assert_raises(ArgumentError) do
-            conf.static_transform Eigen::Vector3.new(0, 0, 0), Eigen::Quaternion.Identity, 10, 'from' => 'to'
-        end
-        assert !conf.has_transformation?("from", "to")
-    end
 
-    def test_dynamic_transform_definition
-        conf.frames "from", "to1", "to2", "to3"
+        describe "frames" do
+            it "declares frames" do
+                conf.frames 'from', 'to'
+                assert conf.has_frame?('from')
+                assert conf.has_frame?('to')
+            end
 
-        conf.dynamic_transform "producer1", 'from' => 'to1'
-        conf.dynamic_transform "producer2", 'from' => 'to2'
-        conf.dynamic_transform "producer3", 'from' => 'to3'
-
-        assert conf.has_transformation?("from", "to1")
-        assert conf.has_transformation?("from", "to2")
-        assert conf.has_transformation?("from", "to3")
-            
-        trsf = conf.transformation_for("from", "to1")
-        assert_equal("producer1", trsf.producer)
-        trsf = conf.transformation_for("from", "to2")
-        assert_equal("producer2", trsf.producer)
-        trsf = conf.transformation_for("from", "to3")
-        assert_equal("producer3", trsf.producer)
-    end
-
-    def test_rejects_invalid_producers
-        conf.frames "from", "to1", "to2", "to3"
-        checker = lambda do |obj|
-            if !obj.kind_of?(String)
-                raise ArgumentError, "producers can only be strings"
+            it "converts symbols to strings" do
+                conf.frames :from
+                assert conf.has_frame?('from')
             end
         end
-        conf.checker = Transformer::ConfigurationChecker.new(checker)
 
-        conf.dynamic_transform "producer1", 'from' => 'to1'
-        assert_raises(ArgumentError) { conf.dynamic_transform("from", "to2", 10) }
-        assert(conf.has_transformation?('from', 'to1'))
-        assert(!conf.has_transformation?('from', 'to2'))
-    end
+        describe "#validate_static_transform_arguments" do
+            it "accepts having only one translation argument" do
+                trans = Eigen::Vector3.new(0, 2, 0)
+                assert_equal ['from', 'to', trans, Eigen::Quaternion.Identity],
+                    conf.validate_static_transform_arguments(trans, 'from' => 'to')
+            end
 
-    def test_it_updates_dynamic_transformations
-        conf.frames "from", "to"
+            it "accepts having only one rotation argument" do
+                q = Eigen::Quaternion.new(0, 1, 0, 0)
+                assert_equal ['from', 'to', Eigen::Vector3.Zero, q],
+                    conf.validate_static_transform_arguments(q, 'from' => 'to')
+            end
 
-        conf.dynamic_transform 'producer1', 'from' => 'to'
-        conf.dynamic_transform 'producer2', 'from' => 'to'
-        assert_equal 'producer2', conf.transformation_for('from', 'to').producer
+            it "accepts having both translation and rotation" do
+                v = Eigen::Vector3.new(0, 2, 0)
+                q = Eigen::Quaternion.new(0, 1, 0, 0)
+                assert_equal ['from', 'to', v, q],
+                    conf.validate_static_transform_arguments(v, q, 'from' => 'to')
+            end
+
+            it "rejects empty transformation definitions" do
+                assert_raises(ArgumentError) do
+                    # No transformation provided
+                    conf.validate_static_transform_arguments "from" => "to"
+                end
+            end
+
+            it "rejects a wrong argument type" do
+                assert_raises(ArgumentError) do
+                    conf.validate_static_transform_arguments 10, 'from' => 'to'
+                end
+                assert_raises(ArgumentError) do
+                    conf.validate_static_transform_arguments 10, Eigen::Vector3.new(0, 0, 0), 'from' => 'to'
+                end
+            end
+
+            it "rejects having too many arguments" do
+                assert_raises(ArgumentError) do
+                    conf.validate_static_transform_arguments Eigen::Vector3.new(0, 0, 0), Eigen::Quaternion.Identity, 10, 'from' => 'to'
+                end
+            end
+        end
+
+        describe "declaration of static transformations" do
+            def assert_has_static_transform(from, to, translation, rotation)
+                assert conf.has_transformation?(from, to)
+                tr = conf.transformation_for(from, to)
+                assert translation.approx?(tr.translation)
+                assert rotation.approx?(tr.rotation)
+            end
+
+            it "registers a validated transformation" do
+                conf.frames 'from', 'to'
+                trans, from, to = Eigen::Vector3.new(1, 0, 0), 'from', 'to'
+                flexmock(conf).should_receive(:validate_static_transform_arguments).
+                    with(trans, from => to).
+                    once.
+                    and_return([from, to, (v = flexmock), flexmock])
+                assert_equal v, conf.static_transform(trans, from => to).translation
+            end
+
+            it "updates existing transformations" do
+                conf.static_transform Eigen::Vector3.new(0, 0, 0), 'from' => 'to'
+                conf.static_transform Eigen::Vector3.new(1, 0, 0), 'from' => 'to'
+                assert_has_static_transform('from', 'to', Eigen::Vector3.new(1, 0, 0), Eigen::Quaternion.Identity)
+            end
+
+        end
+
+        describe "declaration of dynamic transformations" do
+            it "declares a dynamic transform" do
+                conf.dynamic_transform "producer", 'from' => 'to'
+                assert conf.has_transformation?("from", "to")
+                trsf = conf.transformation_for("from", "to")
+                assert_equal("producer", trsf.producer)
+            end
+
+            it "validates the given producers using the configuration checker" do
+                checker = lambda do |obj|
+                    if !obj.kind_of?(String)
+                        raise ArgumentError, "producers can only be strings"
+                    end
+                end
+                conf.checker = Transformer::ConfigurationChecker.new(checker)
+
+                conf.dynamic_transform "producer1", 'from' => 'to1'
+                assert_raises(ArgumentError) { conf.dynamic_transform(10, "from" => "to2") }
+                assert(conf.has_transformation?('from', 'to1'))
+                assert(!conf.has_transformation?('from', 'to2'))
+            end
+
+            it "updates existing transformations" do
+                conf.dynamic_transform 'producer1', 'from' => 'to'
+                conf.dynamic_transform 'producer2', 'from' => 'to'
+                assert_equal 'producer2', conf.transformation_for('from', 'to').producer
+            end
+        end
+
+        describe "declaration of example transformations" do
+            it "registers a validated transformation" do
+                conf.frames 'from', 'to'
+                trans, from, to = Eigen::Vector3.new(1, 0, 0), 'from', 'to'
+                flexmock(conf).should_receive(:validate_static_transform_arguments).
+                    with(trans, from => to).
+                    once.
+                    and_return([from, to, (v = flexmock), flexmock])
+                assert_equal v, conf.example_transform(trans, from => to).translation
+            end
+            it "allows to access the example transformation" do
+                trans, from, to = Eigen::Vector3.new(1, 0, 0), 'from', 'to'
+                conf.example_transform(trans, from => to)
+                tr = conf.example_transformation_for(from, to)
+                assert trans.approx?(tr.translation)
+                assert Eigen::Quaternion.Identity.approx?(tr.rotation)
+                assert_equal 'from', tr.from
+                assert_equal 'to', tr.to
+            end
+            it "raises if trying to access an example transformation for an unknown frame" do
+
+                assert_raises(ArgumentError) { conf.example_transformation_for('from', 'to') }
+                conf.frames 'from1'
+                assert_raises(ArgumentError) { conf.example_transformation_for('from1', 'to1') }
+                conf.frames 'to2'
+                assert_raises(ArgumentError) { conf.example_transformation_for('from2', 'to2') }
+            end
+            it "returns identity as example between two known frames" do
+                conf.frames 'from', 'to'
+                tr = conf.example_transformation_for('from', 'to')
+                assert_equal 'from', tr.from
+                assert_equal 'to', tr.to
+                assert_equal Eigen::Vector3.Zero, tr.translation
+                assert Eigen::Quaternion.Identity.approx?(tr.rotation)
+            end
+        end
     end
 end
-


### PR DESCRIPTION
This contains a bunch of cleanups of the test suite.

The only functionality change is the addition of 'example transformations'. They are meant to provide a typical transformation for a dynamic transform, so that GUIs can display something meaningful even if no data has been received (or, in the case of the rock-transformer tool from gui/vizkit, when no data will ever be received)
