### PR TITLE
ruby: SDF support

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -15,6 +15,7 @@
     <license>LGPL v2 or later</license>
 
     <depend package="drivers/aggregator" />
+    <depend package="tools/ruby_sdf" optional="1"/>
     <tags>stable</tags>
 </package>
 

--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -20,13 +20,13 @@ module Transformer
             end
             if sdf.respond_to?(:each_model)
                 sdf.each_model do |m|
-                    frames m.full_name
+                    frames m.name
 
                     if m.parent.name
                         if m.static?
-                            static_transform(*m.pose, m.full_name => m.parent.full_name)
+                            static_transform(*m.pose, m.name => m.parent.full_name)
                         else
-                            example_transform(*m.pose, m.full_name => m.parent.full_name)
+                            example_transform(*m.pose, m.name => m.parent.full_name)
                         end
                     end
 
@@ -50,10 +50,10 @@ module Transformer
                     child2parent = parent2model.inverse * child2model
                     joint2parent = child2parent * joint2child
 
-                    parent = parent.full_name
-                    child  = child.full_name
-                    joint_pre  = "#{j.full_name}_pre"
-                    joint_post = "#{j.full_name}_post"
+                    parent = "#{sdf.name}::#{parent.name}"
+                    child  = "#{sdf.name}::#{child.name}"
+                    joint_pre  = "#{sdf.name}::#{j.name}_pre"
+                    joint_post = "#{sdf.name}::#{j.name}_post"
                     register_joint(joint_post, joint_pre, j)
                     static_transform(joint2child, joint_post => child)
                     static_transform(joint2parent, joint_pre => parent)
@@ -76,7 +76,7 @@ module Transformer
                 end
 
                 root_links.each_value do |l|
-                    static_transform(*l.pose, l.full_name => l.parent.full_name)
+                    static_transform(*l.pose, "#{sdf.name}::#{l.name}" => sdf.name)
                 end
             end
         end

--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -54,6 +54,7 @@ module Transformer
                     child  = child.full_name
                     joint_pre  = "#{j.full_name}_pre"
                     joint_post = "#{j.full_name}_post"
+                    register_joint(joint_post, joint_pre, j)
                     static_transform(joint2child, joint_post => child)
                     static_transform(joint2parent, joint_pre => parent)
                     if producer_resolver && (p = producer_resolver.call(j))

--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -56,7 +56,7 @@ module Transformer
                     joint_post = "#{j.full_name}_post"
                     static_transform(joint2child, joint_post => child)
                     static_transform(joint2parent, joint_pre => parent)
-                    if producer_resolver && (p = producer_resolver.call(j.full_name))
+                    if producer_resolver && (p = producer_resolver.call(j))
                         dynamic_transform p, joint_post => joint_pre
                     end
 

--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -1,0 +1,79 @@
+require 'sdf'
+
+module Transformer
+    module SDF
+        # Load a SDF model or file and convert it into a transformer configuration
+        def self.load(model_name_or_path, &producer_resolver)
+            sdf = ::SDF::Root.load(model_name_or_path)
+            load_from_sdf(sdf, &producer_resolver)
+        end
+
+        # Create a transformer configuration from SDF model
+        #
+        # @param [SDF::Element] the root of the SDF data that should be used
+        # @return [Transformer::Configuration]
+        def self.load_from_sdf(sdf, &producer_resolver)
+            result = Transformer::Configuration.new
+            parse_sdf(result, sdf, [], &producer_resolver)
+            result
+        end
+
+        # @api private
+        def self.parse_sdf(conf, sdf, prefix, &producer_resolver)
+            if sdf.respond_to?(:each_world)
+                sdf.each_world do |w|
+                    conf.frames w.full_name
+                    parse_sdf(conf, w, prefix + [w.name], &producer_resolver)
+                end
+            end
+            if sdf.respond_to?(:each_model)
+                sdf.each_model do |m|
+                    conf.frames m.full_name
+
+                    if m.parent.name
+                        if m.static?
+                            conf.static_transform(*m.pose, m.full_name => m.parent.full_name)
+                        else
+                            conf.example_transform(*m.pose, m.full_name => m.parent.full_name)
+                        end
+                    end
+
+                    parse_sdf(conf, m, prefix + [m.name], &producer_resolver)
+                end
+            end
+            if sdf.respond_to?(:each_link)
+                root_links = Hash.new
+                sdf.each_link do |l|
+                    root_links[l.name] = l
+                end
+
+                sdf.each_joint do |j|
+                    parent = j.parent_link
+                    child  = j.child_link
+                    root_links.delete(child.name)
+
+                    parent = parent.full_name
+                    child  = child.full_name
+                    if producer_resolver && (p = producer_resolver.call(parent, child))
+                        conf.dynamic_transform p, child => parent
+                    end
+
+                    axis = j.axis
+                    axis_v = axis.xyz
+                    upper = axis.limit.upper || 0
+                    lower = axis.limit.lower || 0
+                    if j.type == 'revolute'
+                        v, q = Eigen::Vector3.Zero, Eigen::Quaternion.from_angle_axis((upper + lower) / 2, axis_v)
+                    else
+                        v, q = xyz.normalize * (upper + lower) / 2, Eigen::Quaternion.Identity
+                    end
+                    conf.example_transform v, q, child => parent
+                end
+
+                root_links.each_value do |l|
+                    conf.static_transform(*l.pose, l.full_name => l.parent.full_name)
+                end
+            end
+        end
+    end
+end

--- a/ruby/test/data/sdf/model_with_child_links/model.config
+++ b/ruby/test/data/sdf/model_with_child_links/model.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+
+<model>
+  <sdf>model.sdf</sdf>
+</model>
+

--- a/ruby/test/data/sdf/model_with_child_links/model.sdf
+++ b/ruby/test/data/sdf/model_with_child_links/model.sdf
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<sdf>
+    <world name="w">
+        <model name="m">
+            <link name="root_link">
+                <pose>1 2 3 90 0 0</pose>
+            </link>
+            <link name="child_link">
+                <pose>1 2 3 90 0 0</pose>
+            </link>
+            <joint name='j' type='revolute'>
+                <parent>root_link</parent>
+                <child>child_link</child>
+                <axis>
+                    <xyz>1 0 0</xyz>
+                </axis>
+            </joint>
+        </model>
+    </world>
+</sdf>
+

--- a/ruby/test/data/sdf/model_with_child_links/model.sdf
+++ b/ruby/test/data/sdf/model_with_child_links/model.sdf
@@ -10,10 +10,15 @@
                 <pose>1 2 3 90 0 0</pose>
             </link>
             <joint name='j' type='revolute'>
+                <pose>1 2 3 0 0 90</pose>
                 <parent>root_link</parent>
                 <child>child_link</child>
                 <axis>
                     <xyz>1 0 0</xyz>
+                    <limit>
+                        <upper>90</upper>
+                        <lower>0</lower>
+                    </limit>
                 </axis>
             </joint>
         </model>

--- a/ruby/test/data/sdf/model_with_child_links/model.sdf
+++ b/ruby/test/data/sdf/model_with_child_links/model.sdf
@@ -10,13 +10,13 @@
                 <pose>1 2 3 90 0 0</pose>
             </link>
             <joint name='j' type='revolute'>
-                <pose>1 2 3 0 0 90</pose>
+                <pose>1 2 3 0 0 2</pose>
                 <parent>root_link</parent>
                 <child>child_link</child>
                 <axis>
                     <xyz>1 0 0</xyz>
                     <limit>
-                        <upper>90</upper>
+                        <upper>3</upper>
                         <lower>0</lower>
                     </limit>
                 </axis>

--- a/ruby/test/data/sdf/model_with_only_root_links/model.config
+++ b/ruby/test/data/sdf/model_with_only_root_links/model.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+
+<model>
+  <sdf>model.sdf</sdf>
+</model>
+

--- a/ruby/test/data/sdf/model_with_only_root_links/model.sdf
+++ b/ruby/test/data/sdf/model_with_only_root_links/model.sdf
@@ -4,7 +4,7 @@
     <world name="w">
         <model name="m">
             <link name="root_link">
-                <pose>1 2 3 0 0 90</pose>
+                <pose>1 2 3 0 0 2</pose>
             </link>
         </model>
     </world>

--- a/ruby/test/data/sdf/model_with_only_root_links/model.sdf
+++ b/ruby/test/data/sdf/model_with_only_root_links/model.sdf
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+
+<sdf>
+    <world name="w">
+        <model name="m">
+            <link name="root_link">
+                <pose>1 2 3 0 0 90</pose>
+            </link>
+        </model>
+    </world>
+</sdf>
+

--- a/ruby/test/data/sdf/model_within_a_world/model.config
+++ b/ruby/test/data/sdf/model_within_a_world/model.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+
+<model>
+  <sdf>model.sdf</sdf>
+</model>
+

--- a/ruby/test/data/sdf/model_within_a_world/model.sdf
+++ b/ruby/test/data/sdf/model_within_a_world/model.sdf
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<sdf>
+    <world name="world_name">
+        <model name="root_model_name" />
+    </world>
+</sdf>
+

--- a/ruby/test/data/sdf/root_model/model.config
+++ b/ruby/test/data/sdf/root_model/model.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+
+<model>
+  <sdf>model.sdf</sdf>
+</model>
+

--- a/ruby/test/data/sdf/root_model/model.sdf
+++ b/ruby/test/data/sdf/root_model/model.sdf
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+
+<sdf>
+    <model name="root_model_name" />
+</sdf>
+

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -23,13 +23,13 @@ module Transformer
 
         it "prefixes frames hierarchically" do
             conf.load_sdf('model://model_within_a_world')
-            assert_equal %w{world_name world_name.root_model_name},
+            assert_equal %w{world_name world_name::root_model_name},
                 conf.frames.to_a.sort
         end
 
         it "creates a static transform between root links and the model" do
             conf.load_sdf('model://model_with_only_root_links')
-            tr = conf.transformation_for('w.m.root_link', 'w.m')
+            tr = conf.transformation_for('w::m::root_link', 'w::m')
             assert Eigen::Vector3.new(1, 2, 3).
                 approx?(tr.translation)
             assert Eigen::Quaternion.from_angle_axis(2, Eigen::Vector3.UnitZ).
@@ -38,7 +38,7 @@ module Transformer
 
         it "creates static transforms between the links and the joints" do
             conf.load_sdf('model://model_with_child_links')
-            tr = conf.transformation_for('w.m.j_post', 'w.m.child_link')
+            tr = conf.transformation_for('w::m::j_post', 'w::m::child_link')
             assert Eigen::Vector3.new(1, 2, 3).
                 approx?(tr.translation)
             assert Eigen::Quaternion.from_angle_axis(2, Eigen::Vector3.UnitZ).
@@ -47,18 +47,18 @@ module Transformer
 
         it "creates dynamic transforms between root links and child links if a transformation producer is given" do
             recorder = flexmock
-            recorder.should_receive(:call).with('w.m.j').once
+            recorder.should_receive(:call).with('w::m::j').once
             conf.load_sdf('model://model_with_child_links') do |joint|
                 recorder.call(joint.full_name)
                 'producer'
             end
-            tr = conf.transformation_for('w.m.j_post', 'w.m.j_pre')
+            tr = conf.transformation_for('w::m::j_post', 'w::m::j_pre')
             assert 'producer', tr.producer
         end
 
         it "always creates example transformations between root links and child links using the axis limits" do
             conf.load_sdf('model://model_with_child_links')
-            tr = conf.example_transformation_for('w.m.j_post', 'w.m.j_pre')
+            tr = conf.example_transformation_for('w::m::j_post', 'w::m::j_pre')
             assert_equal Eigen::Vector3.Zero, tr.translation
             assert Eigen::Quaternion.from_angle_axis(1.5, Eigen::Vector3.UnitX).approx?(tr.rotation)
         end

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -1,0 +1,47 @@
+require 'transformer/test'
+require 'transformer/sdf'
+
+module Transformer
+    describe SDF do
+        before do
+            model_dir = File.expand_path(File.join('data', 'sdf'), File.dirname(__FILE__))
+            @orig_model_path = ::SDF::XML.model_path.dup
+            ::SDF::XML.model_path << model_dir
+        end
+
+        after do
+            ::SDF::XML.model_path = @orig_model_path
+        end
+
+        it "loads a root model just fine" do
+            conf = SDF.load('model://root_model')
+            assert conf.has_frame?('root_model_name')
+        end
+
+        it "prefixes frames hierarchically" do
+            conf = SDF.load('model://model_within_a_world')
+            assert_equal %w{world_name world_name.root_model_name},
+                conf.frames.to_a.sort
+        end
+
+        it "creates a static transform between root links and the model" do
+            conf = SDF.load('model://model_with_only_root_links')
+            tr = conf.transformation_for('w.m.root_link', 'w.m')
+            assert Eigen::Vector3.new(1, 2, 3).
+                approx?(tr.translation)
+            assert Eigen::Quaternion.from_angle_axis(Math::PI/2, Eigen::Vector3.UnitZ).
+                approx?(tr.rotation)
+        end
+
+        it "creates dynamic transforms between root links and child links if a transformation producer is given" do
+            recorder = flexmock
+            recorder.should_receive(:call).with('w.m.root_link', 'w.m.child_link').once
+            conf = SDF.load('model://model_with_child_links') do |parent, child|
+                recorder.call(parent, child)
+                'producer'
+            end
+            tr = conf.transformation_for('w.m.child_link', 'w.m.root_link')
+            assert 'producer', tr.producer
+        end
+    end
+end

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -3,10 +3,13 @@ require 'transformer/sdf'
 
 module Transformer
     describe SDF do
+        attr_reader :conf
+
         before do
             model_dir = File.expand_path(File.join('data', 'sdf'), File.dirname(__FILE__))
             @orig_model_path = ::SDF::XML.model_path.dup
             ::SDF::XML.model_path << model_dir
+            @conf = Configuration.new
         end
 
         after do
@@ -14,19 +17,28 @@ module Transformer
         end
 
         it "loads a root model just fine" do
-            conf = SDF.load('model://root_model')
+            conf.load_sdf('model://root_model')
             assert conf.has_frame?('root_model_name')
         end
 
         it "prefixes frames hierarchically" do
-            conf = SDF.load('model://model_within_a_world')
+            conf.load_sdf('model://model_within_a_world')
             assert_equal %w{world_name world_name.root_model_name},
                 conf.frames.to_a.sort
         end
 
         it "creates a static transform between root links and the model" do
-            conf = SDF.load('model://model_with_only_root_links')
+            conf.load_sdf('model://model_with_only_root_links')
             tr = conf.transformation_for('w.m.root_link', 'w.m')
+            assert Eigen::Vector3.new(1, 2, 3).
+                approx?(tr.translation)
+            assert Eigen::Quaternion.from_angle_axis(Math::PI/2, Eigen::Vector3.UnitZ).
+                approx?(tr.rotation)
+        end
+
+        it "creates a static transform between a child link and a joint" do
+            conf.load_sdf('model://model_with_child_links')
+            tr = conf.transformation_for('w.m.j', 'w.m.child_link')
             assert Eigen::Vector3.new(1, 2, 3).
                 approx?(tr.translation)
             assert Eigen::Quaternion.from_angle_axis(Math::PI/2, Eigen::Vector3.UnitZ).
@@ -35,13 +47,20 @@ module Transformer
 
         it "creates dynamic transforms between root links and child links if a transformation producer is given" do
             recorder = flexmock
-            recorder.should_receive(:call).with('w.m.root_link', 'w.m.child_link').once
-            conf = SDF.load('model://model_with_child_links') do |parent, child|
-                recorder.call(parent, child)
+            recorder.should_receive(:call).with('w.m.root_link', 'w.m.j').once
+            conf.load_sdf('model://model_with_child_links') do |parent, joint|
+                recorder.call(parent, joint)
                 'producer'
             end
-            tr = conf.transformation_for('w.m.child_link', 'w.m.root_link')
+            tr = conf.transformation_for('w.m.j', 'w.m.root_link')
             assert 'producer', tr.producer
+        end
+
+        it "always creates example transformations between root links and child links using the axis limits" do
+            conf.load_sdf('model://model_with_child_links')
+            tr = conf.example_transformation_for('w.m.j', 'w.m.root_link')
+            assert_equal Eigen::Vector3.Zero, tr.translation
+            assert Eigen::Quaternion.from_angle_axis(Math::PI / 4, Eigen::Vector3.UnitX).approx?(tr.rotation)
         end
     end
 end

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -23,13 +23,13 @@ module Transformer
 
         it "prefixes frames hierarchically" do
             conf.load_sdf('model://model_within_a_world')
-            assert_equal %w{world_name world_name::root_model_name},
+            assert_equal %w{root_model_name world_name},
                 conf.frames.to_a.sort
         end
 
         it "creates a static transform between root links and the model" do
             conf.load_sdf('model://model_with_only_root_links')
-            tr = conf.transformation_for('w::m::root_link', 'w::m')
+            tr = conf.transformation_for('m::root_link', 'm')
             assert Eigen::Vector3.new(1, 2, 3).
                 approx?(tr.translation)
             assert Eigen::Quaternion.from_angle_axis(2, Eigen::Vector3.UnitZ).
@@ -38,7 +38,7 @@ module Transformer
 
         it "creates static transforms between the links and the joints" do
             conf.load_sdf('model://model_with_child_links')
-            tr = conf.transformation_for('w::m::j_post', 'w::m::child_link')
+            tr = conf.transformation_for('m::j_post', 'm::child_link')
             assert Eigen::Vector3.new(1, 2, 3).
                 approx?(tr.translation)
             assert Eigen::Quaternion.from_angle_axis(2, Eigen::Vector3.UnitZ).
@@ -52,13 +52,13 @@ module Transformer
                 recorder.call(joint.full_name)
                 'producer'
             end
-            tr = conf.transformation_for('w::m::j_post', 'w::m::j_pre')
+            tr = conf.transformation_for('m::j_post', 'm::j_pre')
             assert 'producer', tr.producer
         end
 
         it "always creates example transformations between root links and child links using the axis limits" do
             conf.load_sdf('model://model_with_child_links')
-            tr = conf.example_transformation_for('w::m::j_post', 'w::m::j_pre')
+            tr = conf.example_transformation_for('m::j_post', 'm::j_pre')
             assert_equal Eigen::Vector3.Zero, tr.translation
             assert Eigen::Quaternion.from_angle_axis(1.5, Eigen::Vector3.UnitX).approx?(tr.rotation)
         end

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -48,8 +48,8 @@ module Transformer
         it "creates dynamic transforms between root links and child links if a transformation producer is given" do
             recorder = flexmock
             recorder.should_receive(:call).with('w.m.j').once
-            conf.load_sdf('model://model_with_child_links') do |joint_name|
-                recorder.call(joint_name)
+            conf.load_sdf('model://model_with_child_links') do |joint|
+                recorder.call(joint.full_name)
                 'producer'
             end
             tr = conf.transformation_for('w.m.j_post', 'w.m.j_pre')

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -32,35 +32,35 @@ module Transformer
             tr = conf.transformation_for('w.m.root_link', 'w.m')
             assert Eigen::Vector3.new(1, 2, 3).
                 approx?(tr.translation)
-            assert Eigen::Quaternion.from_angle_axis(Math::PI/2, Eigen::Vector3.UnitZ).
+            assert Eigen::Quaternion.from_angle_axis(2, Eigen::Vector3.UnitZ).
                 approx?(tr.rotation)
         end
 
-        it "creates a static transform between a child link and a joint" do
+        it "creates static transforms between the links and the joints" do
             conf.load_sdf('model://model_with_child_links')
-            tr = conf.transformation_for('w.m.j', 'w.m.child_link')
+            tr = conf.transformation_for('w.m.j_post', 'w.m.child_link')
             assert Eigen::Vector3.new(1, 2, 3).
                 approx?(tr.translation)
-            assert Eigen::Quaternion.from_angle_axis(Math::PI/2, Eigen::Vector3.UnitZ).
+            assert Eigen::Quaternion.from_angle_axis(2, Eigen::Vector3.UnitZ).
                 approx?(tr.rotation)
         end
 
         it "creates dynamic transforms between root links and child links if a transformation producer is given" do
             recorder = flexmock
-            recorder.should_receive(:call).with('w.m.root_link', 'w.m.j').once
-            conf.load_sdf('model://model_with_child_links') do |parent, joint|
-                recorder.call(parent, joint)
+            recorder.should_receive(:call).with('w.m.j').once
+            conf.load_sdf('model://model_with_child_links') do |joint_name|
+                recorder.call(joint_name)
                 'producer'
             end
-            tr = conf.transformation_for('w.m.j', 'w.m.root_link')
+            tr = conf.transformation_for('w.m.j_post', 'w.m.j_pre')
             assert 'producer', tr.producer
         end
 
         it "always creates example transformations between root links and child links using the axis limits" do
             conf.load_sdf('model://model_with_child_links')
-            tr = conf.example_transformation_for('w.m.j', 'w.m.root_link')
+            tr = conf.example_transformation_for('w.m.j_post', 'w.m.j_pre')
             assert_equal Eigen::Vector3.Zero, tr.translation
-            assert Eigen::Quaternion.from_angle_axis(Math::PI / 4, Eigen::Vector3.UnitX).approx?(tr.rotation)
+            assert Eigen::Quaternion.from_angle_axis(1.5, Eigen::Vector3.UnitX).approx?(tr.rotation)
         end
     end
 end


### PR DESCRIPTION
This provides the functionality to use a SDF file to initialize a transformer configuration object. In addition, it extends the transformer configuration to store transform-to-joint information (pure names), something that could be used for other robot description formats as well.

The functionality is located in a single file which is not loaded by default, thus keeping the dependency on control/ruby_sdformat optional.
