### PR TITLE
Fix syskit test suite

### DIFF
--- a/ruby/lib/transformer/syskit.rb
+++ b/ruby/lib/transformer/syskit.rb
@@ -1,3 +1,4 @@
+require 'transformer/syskit/configuration'
 require 'transformer/syskit/exceptions'
 require 'transformer/syskit/extensions'
 require 'transformer/syskit/frame_propagation'

--- a/ruby/lib/transformer/syskit/configuration.rb
+++ b/ruby/lib/transformer/syskit/configuration.rb
@@ -1,0 +1,9 @@
+module Transformer
+    class SyskitConfiguration < Configuration
+        def dynamic_transform(producer, *frames)
+            producer = producer.to_instance_requirements
+            super(producer, *frames)
+        end
+    end
+end
+

--- a/ruby/lib/transformer/syskit/extensions/configuration.rb
+++ b/ruby/lib/transformer/syskit/extensions/configuration.rb
@@ -1,12 +1,23 @@
 module Transformer
     module ConfigurationExtension
-        attr_predicate :transformer_enabled?, true
+        attr_predicate :transformer_enabled?
 
         def transformer_enabled=(value)
             if value
                 Transformer::SyskitPlugin.enable
             end
             @transformer_enabled = value
+        end
+
+        def transformer_warn_about_unset_frames?
+            if !instance_variable_defined?(:@transformer_warn_about_unset_frames)
+                true
+            else @transformer_warn_about_unset_frames
+            end
+        end
+
+        def transformer_warn_about_unset_frames=(flag)
+            @transformer_warn_about_unset_frames = flag
         end
 
 	def transformer_broadcaster_enabled?

--- a/ruby/lib/transformer/syskit/extensions/instance_requirements.rb
+++ b/ruby/lib/transformer/syskit/extensions/instance_requirements.rb
@@ -14,7 +14,7 @@ module Transformer
         attr_writer :transformer
 
         def transformer
-            @transformer ||= Transformer::Configuration.new
+            @transformer ||= SyskitConfiguration.new
             if block_given?
                 @transformer.instance_eval(&proc)
                 return self

--- a/ruby/lib/transformer/syskit/extensions/plan.rb
+++ b/ruby/lib/transformer/syskit/extensions/plan.rb
@@ -1,7 +1,7 @@
 module Transformer
     module PlanExtension
         attribute(:transformer_configuration_state) do
-            [Time.now, Types::Transformer::ConfigurationState.new]
+            [Time.now, Types.transformer.ConfigurationState.new]
         end
 
         # Propagates the transformer_configuration_state changes to the underlying plan

--- a/ruby/lib/transformer/syskit/extensions/profile.rb
+++ b/ruby/lib/transformer/syskit/extensions/profile.rb
@@ -5,7 +5,7 @@ module Transformer
     module ProfileExtension
         # This is a normal transformer configuration with only a few added
         # tweaks
-        class Configuration < Transformer::Configuration
+        class Configuration < SyskitConfiguration
             attr_accessor :profile
             def initialize(profile)
                 @profile = profile

--- a/ruby/lib/transformer/syskit/extensions/task_context.rb
+++ b/ruby/lib/transformer/syskit/extensions/task_context.rb
@@ -156,17 +156,15 @@ module Transformer
         # property exists to change it) and 'global' is not its hardcoded value.
         def select_frames(selection)
             return if !(tr = model.transformer)
+            selection = selection.find_all { |local_frame, _| tr.has_frame?(local_frame) }
             selection.each do |local_frame, global_frame|
                 # If the frame is not configurable, raise
                 if tr.static?(local_frame) && local_frame != global_frame
                     raise StaticFrameChangeError.new(self, local_frame, global_frame), "cannot select #{global_frame} for the local frame #{local_frame} in #{self}, as the component does not support configuring that frame"
                 end
             end
-
-            selection.each do |name, selected_frame|
-                if tr.has_frame?(name)
-                    select_frame(name, selected_frame, validate: false)
-                end
+            selection.each do |local_frame, global_frame|
+                select_frame(local_frame, global_frame, validate: false)
             end
         end
 

--- a/ruby/lib/transformer/syskit/plugin.rb
+++ b/ruby/lib/transformer/syskit/plugin.rb
@@ -97,12 +97,9 @@ module Transformer
             producer_task.transformer.merge(manager.conf)
             propagate_local_transformer_configuration(producer_task)
 
-            Transformer.debug do
-                Transformer.debug "instanciated #{producer_task} for #{task}"
-                break
-            end
-
+            Transformer.debug { "instanciated #{producer_task} for #{task}" }
             transformations.each do |dyn|
+                Transformer.debug { "adding #{producer_task} as child transformer_#{dyn.from}2#{dyn.to} of #{task}" }
                 task.depends_on(producer_task, :role => "transformer_#{dyn.from}2#{dyn.to}")
 
                 out_port = producer.find_port_for_transform(dyn.from, dyn.to)
@@ -199,7 +196,7 @@ module Transformer
                         info = Types::Transformer::PortFrameAssociation.new(
                             :task => task_name, :port => port.name, :frame => selected_frame)
                         state.port_frame_associations << info
-                    else
+                    elsif Syskit.conf.transformer_warn_about_unset_frames?
                         Transformer.warn "no frame selected for #{frame_name} on #{task}. This is harmless for the network to run, but will make the display of #{port.name} \"in the right frame\" impossible"
                     end
                 end
@@ -213,7 +210,7 @@ module Transformer
                             :task => task_name, :port => port.name,
                             :from_frame => from, :to_frame => to)
                         state.port_transformation_associations << info
-                    else
+                    elsif Syskit.conf.transformer_warn_about_unset_frames?
                         Transformer.warn "no frame selected for #{transform.to} on #{task}. This is harmless for the network to run, but might remove some options during display"
                     end
                 end

--- a/ruby/lib/transformer/syskit/test.rb
+++ b/ruby/lib/transformer/syskit/test.rb
@@ -4,11 +4,10 @@ require 'transformer/syskit'
 module Transformer
     module SyskitPlugin
         module SelfTest
-            include Syskit::Test::Self
-
             def setup
                 super
                 Orocos.export_types = true
+                Syskit.conf.transformer_warn_about_unset_frames = false
                 Syskit.conf.transformer_enabled = true
             end
         end


### PR DESCRIPTION
It depended on an external test_transformer orogen project, which is gone. Convert the test suite to remove the dependency on any test project.
