### PR TITLE
Use templated inline functions to determine the timestamp of a sample types

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,5 +3,6 @@ rock_library(transformer
 	    NonAligningTransformer.cpp
     HEADERS Transformer.hpp TransformationStatus.hpp
 	    NonAligningTransformer.hpp
+	    DetermineSampleTimestamp.hpp
     DEPS_PKGCONFIG aggregator base-types)
 

--- a/src/DetermineSampleTimestamp.hpp
+++ b/src/DetermineSampleTimestamp.hpp
@@ -1,0 +1,45 @@
+#ifndef _TRANSFORMER_DETERMINE_SAMPLE_TIMESTAMP_HPP_
+#define _TRANSFORMER_DETERMINE_SAMPLE_TIMESTAMP_HPP_
+
+#include <base/Time.hpp>
+#include <boost/shared_ptr.hpp>
+#include <stdexcept>
+
+namespace base { namespace samples
+{
+
+/**
+ * These methods are used to lookup the timestamp of a sample type.
+ * It is assumed that these types have a public field of type base::Time
+ * named time, which is the case for all base::samples::* types.
+ * For types where this assumption is not true, it is possible to specialized
+ * the method in the same namespace which provides a timestamp for this type.
+ * E.g.:
+ * namespace base { namespace samples {
+ *      inline base::Time determineTimestamp(const some_namespace::SomeSampleType& type) {...}
+ * }}
+ */
+
+template<typename T>
+inline base::Time determineTimestamp(const T& type)
+{
+    return type.time;
+}
+
+template<typename T>
+inline base::Time determineTimestamp(const T* type)
+{
+    if (type == NULL) throw std::runtime_error("determineTimestamp: Received null pointer in function!");
+    return determineTimestamp(*type);
+}
+
+template<typename T>
+inline base::Time determineTimestamp(const boost::shared_ptr<T>& type)
+{
+    if (type.get() == NULL) throw std::runtime_error("determineTimestamp: Received null pointer in function!");
+    return determineTimestamp(*type);
+}
+
+}}
+
+#endif


### PR DESCRIPTION
This is a proposal to change the current lookup of timestamps in the transformer.
This would allow to specialize the function for a certain type in case it doesn't have a public field called time.
The namespace doesn't has to be base::samples, I'm open for other suggestions.
It would also be possible to add a function to handle the RTT ReadOnlyPointer here and get rid of the distinction in the tasks, but it would add a dependency to RTT.
