### PR TITLE
Improve error cases

### DIFF
--- a/src/Transformer.cpp
+++ b/src/Transformer.cpp
@@ -261,7 +261,11 @@ bool DynamicTransformationElement::getTransformation(const base::Time& atTime, b
         interpolated.initSane();
 
         double timeBetweenTransforms = (next_sample.first - lastTransformTime).toSeconds();
-        assert(timeBetweenTransforms > timeForward);
+        if(timeBetweenTransforms <= timeForward)
+        {
+            LOG_ERROR_S << "Error, time of sample is higher than next transformation time";
+            throw std::runtime_error("Error, time of sample is higher than next transformation time");
+        }
         
         double factor = timeForward / timeBetweenTransforms;
         


### PR DESCRIPTION
This adds some more error messages and changes one assert to a message+throw because the assertion is not backed by documentation or code structure, so aborting the process seems a bit harsh.