### PR TITLE
Add/improve documentation for Transformation, Transformer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0)
+project(transformer VERSION 0.1)
 find_package(Rock)
-rock_init(transformer 0.1)
+rock_init()
 rock_standard_layout()
 
 include(RockRuby)

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -155,13 +155,6 @@ QT_AUTOBRIEF           = NO
 
 MULTILINE_CPP_IS_BRIEF = NO
 
-# If the DETAILS_AT_TOP tag is set to YES then Doxygen 
-# will output the detailed description near the top, like JavaDoc.
-# If set to NO, the detailed description appears after the member 
-# documentation.
-
-DETAILS_AT_TOP         = NO
-
 # If the INHERIT_DOCS tag is set to YES (the default) then an undocumented 
 # member inherits the documentation from any documented member that it 
 # re-implements.
@@ -445,12 +438,6 @@ MAX_INITIALIZER_LINES  = 30
 # list will mention the files that were used to generate the documentation.
 
 SHOW_USED_FILES        = YES
-
-# If the sources in your project are distributed over multiple directories 
-# then setting the SHOW_DIRECTORIES tag to YES will show the directory hierarchy 
-# in the documentation. The default is NO.
-
-SHOW_DIRECTORIES       = NO
 
 # Set the SHOW_FILES tag to NO to disable the generation of the Files page.
 # This will remove the Files entry from the Quick Index and from the 
@@ -758,12 +745,6 @@ HTML_FOOTER            =
 
 HTML_STYLESHEET        = 
 
-# If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes, 
-# files or namespaces will be aligned in HTML using tables. If set to 
-# NO a bullet list will be used.
-
-HTML_ALIGN_MEMBERS     = YES
-
 # If the GENERATE_HTMLHELP tag is set to YES, additional index files 
 # will be generated that can be used as input for tools like the 
 # Microsoft HTML help workshop to generate a compiled HTML help file (.chm) 
@@ -1045,18 +1026,6 @@ GENERATE_XML           = NO
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify an XML schema, 
-# which can be used by a validating XML parser to check the 
-# syntax of the XML files.
-
-XML_SCHEMA             = 
-
-# The XML_DTD tag can be used to specify an XML DTD, 
-# which can be used by a validating XML parser to check the 
-# syntax of the XML files.
-
-XML_DTD                = 
-
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will 
 # dump the program listings (including syntax highlighting 
 # and cross-referencing information) to the XML output. Note that 
@@ -1213,11 +1182,6 @@ ALLEXTERNALS           = NO
 
 EXTERNAL_GROUPS        = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script 
-# interpreter (i.e. the result of `which perl').
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool   
 #---------------------------------------------------------------------------
@@ -1230,15 +1194,6 @@ PERL_PATH              = /usr/bin/perl
 # powerful graphs.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc 
-# command. Doxygen will then run the mscgen tool (see 
-# http://www.mcternan.me.uk/mscgen/) to produce the chart and insert it in the 
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where 
-# the mscgen tool resides. If left empty the tool is assumed to be found in the 
-# default search path.
-
-MSCGEN_PATH            = 
 
 # If set to YES, the inheritance and collaboration graphs will hide 
 # inheritance and usage relations if the target is undocumented 
@@ -1262,7 +1217,7 @@ HAVE_DOT               = NO
 # DOTFONTPATH environment variable or by setting DOT_FONTPATH to the directory 
 # containing the font.
 
-DOT_FONTNAME           = FreeSans
+DOT_FONTNAME           =
 
 # By default doxygen will tell dot to use the output directory to look for the 
 # FreeSans.ttf font (which doxygen will put there itself). If you specify a 

--- a/src/Transformation.hpp
+++ b/src/Transformation.hpp
@@ -9,6 +9,13 @@
 
 namespace transformer
 {
+    /** The transformation between two frames
+     *
+     * Objects of this type can be used to get the current relative
+     * transformation between the involved frames.
+     *
+     * These are constructed by Transformer::registerTransformation
+     */
     class Transformation
     {
     friend class Transformer;
@@ -47,24 +54,30 @@ namespace transformer
         * required transformation
         *
         * Calling this method sets the transformation as valid.
+        *
+        * @param chain  The transformation chain
         * */
         void setTransformationChain(const std::vector<TransformationElement *> &chain);
 
         Transformation(const Transformation &other){}
 
     public:
-        /** Updates the data contained in the provided status structure with the
-        * transformation's internal information
+        /** Returns a status structure with data derived from the
+         * transformation's internal information
+        * @returns The updated status structure
         */
         TransformationStatus getStatus() const;
 
         /** Updates the data contained in the provided status structure with the
         * transformation's internal information
+        *
+        * @param status  The status structure to be updated.
         */
         void updateStatus(TransformationStatus& status) const;
 
         /**
-        * returns the souce frame
+        * returns the source frame
+        * @return The source frame
         * */
         const std::string &getSourceFrame() const
         {
@@ -76,6 +89,7 @@ namespace transformer
 
         /**
         * returns the target frame
+        * @return The target frame
         * */
         const std::string &getTargetFrame() const
         {
@@ -100,22 +114,104 @@ namespace transformer
         }
 
         /**
-        * Registeres a callback (only one) callback, that is called,
-        * whenever this transformation changes.
+        * Registers a callback that is called whenever this transformation changes.
+        *
+        * There can only be one callback; the last setting is overwritten
+        * by this new callback
+        *
+        * @param callback   The callback to be called. The single parameter
+        *                   is the timestamp of the change.
+        *                   To unregister the last callback, the parameter
+        *                   can be set to
+        *                   boost::function<void (const base::Time &ts)>()
         * */
         void registerUpdateCallback(boost::function<void (const base::Time &ts)> callback);
 
         /**
-        * This functions tries to return the transformation from sourceFrame to targetFrame at the given time.
+        * This function tries to return the transformation from sourceFrame to targetFrame at the given time.
         * 
         * If no chain, or no transformation samples are available the function will return false
-        * Else it will return true and store the requested transformation in @param result
+        * Else it will return true and store the requested transformation in result
+        *
+        * @sa get(const base::Time& atTime, T& result, bool interpolate) const
+        *
+        * @param atTime      This is the time that is used to interpolate the
+        *                    transformation. It must be equal or newer than the
+        *                    latest timestamp reported via the callback, it
+        *                    must be older than the next sample from any of the
+        *                    involved dynamic transformations.
+        *                    atTime is only used to populate result.time
+        *                    when interpolate is false.
+        * @param result      The calculated transformation, from a freshly
+        *                    initialized TransformationType, with sourceFrame
+        *                    and targetFrame set to the configured values and
+        *                    time set to atTime.
+        * @param interpolate If set to true, the final transformation will be
+        *                    calculated from interpolated versions of all of
+        *                    the involved dynamic transformations.
+        *                    Else, the the latest samples that are older or
+        *                    same age as the time reported through the callback
+        *                    will be used.
+        * @return            True if a transformation was produced.
         * */
         bool get(const base::Time& atTime, transformer::TransformationType& result, bool interpolate = false) const;
+
+        /**
+        * This function tries to return the transformation from sourceFrame to targetFrame at the given time.
+        *
+        * If no chain, or no transformation samples are available the function will return false
+        * Else it will return true and store the requested transformation in result
+        *
+        * @param atTime      This is the time that is used to interpolate the
+        *                    transformation. It must be equal or newer than the
+        *                    latest timestamp reported via the callback, it
+        *                    must be older than the next sample from any of the
+        *                    involved dynamic transformations.
+        *                    atTime is only used to fill the time member
+        *                    variables when interpolate is false.
+        * @param result      The calculated transformation chain. The time
+        *                    members will be set to atTime
+        * @param interpolate If set to true, the final transformation will be
+        *                    calculated from interpolated versions of all of
+        *                    the involved dynamic transformations.
+        *                    Else, the the latest samples that are older or
+        *                    same age as the time reported through the callback
+        *                    will be used.
+        * @return            True if a transformation was produced.
+        * */
         bool getChain(const base::Time& atTime, std::vector<TransformationType>& result, bool interpolate = false) const;
 
+        /**
+        * This function tries to return the transformation from sourceFrame to targetFrame at the given time.
+        *
+        * If no chain, or no transformation samples are available the function will return false
+        * Else it will return true and store the requested transformation in result
+        *
+        * @sa get(const base::Time& atTime, transformer::TransformationType& result, bool interpolate) const
+        *
+        * @param atTime      This is the time that is used to interpolate the
+        *                    transformation. It must be equal or newer than the
+        *                    latest timestamp reported via the callback, it
+        *                    must be older than the next sample from any of the
+        *                    involved dynamic transformations.
+        *                    atTime is ignored when interpolate is false.
+        * @param result      The calculated transformation, from a freshly
+        *                    initialized T.
+        * @param interpolate If set to true, the final transformation will be
+        *                    calculated from interpolated versions of all of
+        *                    the involved dynamic transformations.
+        *                    Else, the the latest samples that are older or
+        *                    same age as the time reported through the callback
+        *                    will be used.
+        * @return            True if a transformation was produced.
+        * */
         template <class T>
         bool get(const base::Time& atTime, T& result, bool interpolate = false) const;
+
+        /**
+        *
+        * \copydoc getChain(const base::Time&,std::vector<TransformationType>&,bool) const
+        * */
         bool getChain(const base::Time& atTime, std::vector<Eigen::Affine3d>& result, bool interpolate = false) const;
     };
 

--- a/src/Transformer.hpp
+++ b/src/Transformer.hpp
@@ -382,8 +382,23 @@ namespace transformer
         /**
          * @deprecated
          *
-         * This never worked, except for boolean typed streams.
+         * This was required to use a previous version of
+         * registerTransformCallback(registerTransfromCallback)
+         * that created a bool typed stream.
+         *
+         * The current implementation of registerTransformCallback
+         * no longer requires a call to requestTransformationAtTime.
+         *
+         * This only works with indexes of bool typed streams.
+         *
+         * See commit 299857530298fd43912d341cdd273dc20c83fd9a,
+         * a35ede8dd0f84dfefb36627033c1df5c72b56ff1
          */
+#if defined(__cplusplus) && (__cplusplus >= 201402L)
+        [[deprecated("No longer needed with registerTransformCallback")]]
+#elif defined(__GNUC__) || defined(__clang__)
+        __attribute__((deprecated("No longer needed with registerTransformCallback")))
+#endif
         void requestTransformationAtTime(int idx, base::Time ts)
         {
             aggregator.push(idx, ts, false);


### PR DESCRIPTION
The copydocs from the aggregator had to be inserted directly, doxygen does not want to copy from things it did not document in the same run.

Also note that i documented transformer::Transformer::requestTransformationAtTime as deprecated since i cannot see how it would compile for anything but boolean streams.